### PR TITLE
added 2 tests to TestStartServer

### DIFF
--- a/tests/test_server_start.py
+++ b/tests/test_server_start.py
@@ -5,9 +5,8 @@ sys.path.append('../')
 from server_start import StartServer
 
 
-
 class TestServer():
-# run tests for client
+
     def setup_method(self):
         self.server = StartServer(test=True)
 

--- a/tests/test_server_tor.py
+++ b/tests/test_server_tor.py
@@ -1,0 +1,22 @@
+# trunk-ignore(flake8/E402)
+from server.server_tor import CreateOnion
+
+
+
+
+class TestStartServer():
+
+    def setup_method(self):
+        self.onion = CreateOnion()
+
+    # test if ephemeral_onion is created
+    def test_ephemeral_onion(self):
+        address = self.onion.ephemeral_onion()
+        # check if the address is 56 characters long
+        assert len(address.service_id) == 56
+
+    # test if non_ephemeral_onion is created
+    def test_non_ephemeral_onion(self):
+        address = self.onion.non_ephemeral_onion()
+        # check if the address is 56 characters long
+        assert len(address.service_id) == 56


### PR DESCRIPTION
Created 2 new tests, and new warning created, setDaemon() is deprecated. THis can only be fixed by the stem devs.
Added test: 
test_ephemeral_onion, test_non_ephemeral_onion